### PR TITLE
Add shared common_paths module and fix imports

### DIFF
--- a/Appointments/main_v2.py
+++ b/Appointments/main_v2.py
@@ -5,6 +5,10 @@ import csv
 from datetime import datetime, date
 import os
 from tkcalendar import Calendar
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from common_paths import data_dir, find_latest_csv
 
 # Example A: open the latest "appointments_" CSV automatically

--- a/Payments/main_v2.py
+++ b/Payments/main_v2.py
@@ -5,6 +5,10 @@ import csv
 from datetime import datetime
 import os
 from tkcalendar import Calendar
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from common_paths import data_dir, find_latest_csv
 
 # Example A: open the latest "appointments_" CSV automatically

--- a/Pending/main_v2.py
+++ b/Pending/main_v2.py
@@ -5,6 +5,10 @@ import csv
 from datetime import datetime
 import os
 from tkcalendar import Calendar
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from common_paths import data_dir, find_latest_csv
 
 # Example A: open the latest "appointments_" CSV automatically

--- a/common_paths.py
+++ b/common_paths.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Shared helper functions for locating user data files."""
+
+from pathlib import Path
+import os
+import sys
+
+APP_NAME = "ScriptLauncher"
+
+
+def base_dir() -> Path:
+    """Return directory containing this application or executable."""
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).parent
+    return Path(__file__).resolve().parent
+
+
+def data_dir() -> Path:
+    """Return the directory where user data (CSV files) is stored.
+
+    Creates the directory if it does not already exist.
+    """
+    root_dir = Path(os.getenv("LOCALAPPDATA", base_dir()))
+    d = root_dir / APP_NAME / "data"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def find_latest_csv(prefix: str) -> Path | None:
+    """Return the most recently modified CSV file starting with ``prefix``.
+
+    Parameters
+    ----------
+    prefix:
+        Filename prefix to match, e.g. ``"appointments_"``.
+
+    Returns
+    -------
+    Path | None
+        Path to the latest matching CSV file or ``None`` if none exist.
+    """
+    candidates = sorted(
+        data_dir().glob(f"{prefix}*.csv"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None


### PR DESCRIPTION
## Summary
- provide shared helper `common_paths` for locating data files
- update appointment, payment, and pending scripts to import it via parent path

## Testing
- `python -m py_compile common_paths.py Appointments/main_v2.py Payments/main_v2.py Pending/main_v2.py`

------
https://chatgpt.com/codex/tasks/task_b_68bed810571c832aad38a21b44d5f488