### PR TITLE
Resolve payment CSV lookup and missing fonts in pending PDFs

### DIFF
--- a/Payments/main_v2.py
+++ b/Payments/main_v2.py
@@ -46,16 +46,28 @@ def generate_payment_pdf():
         var_date = datetime.strptime(selected_date, "%m/%d/%y").strftime("%Y-%m-%d")
         c_var_date = datetime.strptime(selected_date, "%m/%d/%y").strftime("%Y%m%d")
 
-        csv_filename = f'payments_{var_date}.csv'
-        if not os.path.exists(csv_filename):
+        csv_filename = f"payments_{var_date}.csv"
+        csv_path = data_dir() / csv_filename
+        if not csv_path.exists():
             messagebox.showerror("File Not Found", f"CSV file not found for date: {var_date}")
             return
 
         pdf = PDF(orientation='P', unit='mm', format='A4')
 
-        pdf.add_font('Novecento Wide Demi Bold', 'B',
-                     r"C:\Users\user\AppData\Local\Microsoft\Windows\Fonts\Novecentowide-Bold.ttf", uni=True)
-        pdf.add_font('Armata Regular', '', r"C:\Users\user\AppData\Local\Microsoft\Windows\Fonts\Armata-Regular.ttf", uni=True)
+        root_dir = Path(__file__).resolve().parents[1]
+        font_dir = root_dir / "Fonts"
+        pdf.add_font(
+            'Novecento Wide Demi Bold',
+            'B',
+            str(font_dir / 'Novecentowide-Bold.ttf'),
+            uni=True,
+        )
+        pdf.add_font(
+            'Armata Regular',
+            '',
+            str(font_dir / 'Armata-Regular.ttf'),
+            uni=True,
+        )
         pdf.add_font('Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf", uni=True)
         pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf", uni=True)
         pdf.add_font('Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf", uni=True)
@@ -68,7 +80,7 @@ def generate_payment_pdf():
 
         pdf.set_font('Trebuchet MS Regular', '', 7)
 
-        with open(csv_filename, newline='', encoding='utf8') as f:
+        with open(csv_path, newline='', encoding='utf8') as f:
             reader = csv.reader(f)
             next(reader)
             sortedlist = filter(None, reader)

--- a/Pending/main_v2.py
+++ b/Pending/main_v2.py
@@ -47,16 +47,28 @@ def generate_pending_pdf():
         var_date = datetime.strptime(selected_date, "%m/%d/%y").strftime("%Y-%m-%d")
         var_date_num = datetime.strptime(selected_date, "%m/%d/%y").strftime("%m")
         c_var_date = datetime.strptime(selected_date, "%m/%d/%y").strftime("%Y%m%d")
-        csv_filename = f'appointments_{var_date}.csv'
+        csv_filename = f"appointments_{var_date}.csv"
+        csv_path = data_dir() / csv_filename
 
-        if not os.path.exists(csv_filename):
+        if not csv_path.exists():
             messagebox.showerror("File Not Found", f"CSV file not found: {csv_filename}")
             return
 
         pdf = PDF(orientation='P', unit='mm', format='A4')
-        pdf.add_font('Novecento Wide Demi Bold', 'B',
-                     r"C:\Users\user\AppData\Local\Microsoft\Windows\Fonts\Novecentowide-Bold.ttf", uni=True)
-        pdf.add_font('Armata Regular', '', r"C:\Users\user\AppData\Local\Microsoft\Windows\Fonts\Armata-Regular.ttf", uni=True)
+        root_dir = Path(__file__).resolve().parents[1]
+        font_dir = root_dir / "Fonts"
+        pdf.add_font(
+            'Novecento Wide Demi Bold',
+            'B',
+            str(font_dir / 'Novecentowide-Bold.ttf'),
+            uni=True,
+        )
+        pdf.add_font(
+            'Armata Regular',
+            '',
+            str(font_dir / 'Armata-Regular.ttf'),
+            uni=True,
+        )
         pdf.add_font('Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf", uni=True)
         pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf", uni=True)
         pdf.add_font('Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf", uni=True)
@@ -67,7 +79,7 @@ def generate_pending_pdf():
         th = 5
         pdf.set_font('Trebuchet MS Regular', '', 7)
 
-        with open(csv_filename, newline='', encoding='utf8') as f:
+        with open(csv_path, newline='', encoding='utf8') as f:
             reader = csv.reader(f)
             next(reader)
             sortedlist = filter(None, reader)


### PR DESCRIPTION
## Summary
- Use `data_dir` to locate payment CSV files based on date selection
- Load Novecento and Armata fonts from the bundled `Fonts` directory to avoid missing-font errors

## Testing
- `python -m py_compile Payments/main_v2.py Pending/main_v2.py`


------
https://chatgpt.com/codex/tasks/task_b_68bedba9bd2c832aa3075735db3bdb49