### PR TITLE
Center Tkinter launcher and sub-app windows

### DIFF
--- a/Appointments/main_v2.py
+++ b/Appointments/main_v2.py
@@ -54,12 +54,24 @@ def generate_pdf():
             return
 
         pdf = PDF(orientation='P', unit='mm', format='A4')
-        pdf.add_font('Novecento Wide Demi Bold', 'B',
-                     r"C:\Users\donit\AppData\Local\Microsoft\Windows\Fonts\Novecentowide-Bold.ttf", uni=True)
-        pdf.add_font('Armata Regular', '', r"C:\Users\donit\AppData\Local\Microsoft\Windows\Fonts\Armata-Regular.ttf", uni=True)
-        pdf.add_font('Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf", uni=True)
-        pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf", uni=True)
-        pdf.add_font('Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf", uni=True)
+
+        root_dir = Path(__file__).resolve().parents[1]
+        font_dir = root_dir / "Fonts"
+        pdf.add_font(
+            'Novecento Wide Demi Bold',
+            'B',
+            str(font_dir / 'Novecentowide-Bold.ttf'),
+            uni=True,
+        )
+        pdf.add_font(
+            'Armata Regular',
+            '',
+            str(font_dir / 'Armata-Regular.ttf'),
+            uni=True,
+        )
+        pdf.add_font('Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf", uni=True)
+        pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf", uni=True)
+        pdf.add_font('Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf", uni=True)
 
         pdf.add_page()
         pdf.alias_nb_pages()
@@ -124,5 +136,15 @@ cal.pack(pady=10)
 
 btn_generate = tk.Button(frame, text="Load & Generate PDF", command=generate_pdf, width=30, pady=10)
 btn_generate.pack(pady=10)
+def center_window(win):
+    win.update_idletasks()
+    width = win.winfo_width()
+    height = win.winfo_height()
+    x = (win.winfo_screenwidth() - width) // 2
+    y = (win.winfo_screenheight() - height) // 2
+    win.geometry(f"{width}x{height}+{x}+{y}")
+
+center_window(root)
+root.resizable(False, False)
 
 root.mainloop()

--- a/Payments/main_v2.py
+++ b/Payments/main_v2.py
@@ -136,5 +136,15 @@ cal.pack(pady=10)
 
 btn_generate = tk.Button(frame, text="Generate Payment PDF", command=generate_payment_pdf, width=30, pady=10)
 btn_generate.pack(pady=10)
+def center_window(win):
+    win.update_idletasks()
+    width = win.winfo_width()
+    height = win.winfo_height()
+    x = (win.winfo_screenwidth() - width) // 2
+    y = (win.winfo_screenheight() - height) // 2
+    win.geometry(f"{width}x{height}+{x}+{y}")
+
+center_window(root)
+root.resizable(False, False)
 
 root.mainloop()

--- a/Pending/main_v2.py
+++ b/Pending/main_v2.py
@@ -137,5 +137,15 @@ cal.pack(pady=10)
 
 btn_generate = tk.Button(frame, text="Generate Pending PDF", command=generate_pending_pdf, width=30, pady=10)
 btn_generate.pack(pady=10)
+def center_window(win):
+    win.update_idletasks()
+    width = win.winfo_width()
+    height = win.winfo_height()
+    x = (win.winfo_screenwidth() - width) // 2
+    y = (win.winfo_screenheight() - height) // 2
+    win.geometry(f"{width}x{height}+{x}+{y}")
+
+center_window(root)
+root.resizable(False, False)
 
 root.mainloop()

--- a/home.py
+++ b/home.py
@@ -43,11 +43,14 @@ def main():
     root = tk.Tk()
     root.withdraw()
 
+    # Ensure relative resources resolve beside the executable
+    os.chdir(base_dir())
+
     # Load private fonts before creating tkfont.Font objects
     load_private_fonts([
-        "Fonts/Armata-Regular.ttf",
-        "Fonts/Novecentowide-Bold.ttf",
-        "Fonts/Novecentowide-DemiBold_0.ttf",
+        base_dir() / "Fonts" / "Armata-Regular.ttf",
+        base_dir() / "Fonts" / "Novecentowide-Bold.ttf",
+        base_dir() / "Fonts" / "Novecentowide-DemiBold_0.ttf",
     ])
 
     def choose_family(preferred_names, fallbacks=("Segoe UI", "Arial", "Tahoma")):
@@ -69,15 +72,23 @@ def main():
 
     # ---------- UI ----------
     root.title("Script Launcher")
-    root.geometry("550x420")
+    width, height = 550, 420
+    root.geometry(f"{width}x{height}")
+    root.update_idletasks()
+    x = (root.winfo_screenwidth() - width) // 2
+    y = (root.winfo_screenheight() - height) // 2
+    root.geometry(f"{width}x{height}+{x}+{y}")
     root.resizable(False, False)
-    root.configure(bg="#f0f0f0")
+    root.configure(bg="#e9ecef")
 
     style = ttk.Style(root)
     style.theme_use("clam")
-    style.configure("TFrame", background="#f0f0f0")
-    style.configure("TButton", background="#f0f0f0", padding=6)
-    style.configure("TLabel", background="#f0f0f0")
+    style.configure("TFrame", background="#e9ecef")
+    style.configure("TButton", background="#ffffff", padding=6, relief="flat")
+    style.map("TButton", background=[("active", "#d4d4d4")])
+    style.configure("TLabel", background="#e9ecef")
+    style.configure("Treeview", background="#ffffff", fieldbackground="#ffffff", bordercolor="#d9d9d9")
+    style.configure("Treeview.Heading", font=btn_font, background="#d9d9d9")
 
     button_frame = ttk.Frame(root, padding=20)
     button_frame.pack(side="left", fill="y", padx=10)

--- a/pdf.py
+++ b/pdf.py
@@ -53,8 +53,13 @@ def show_pdf_list(folder_name):
 
     window = tk.Toplevel()
     window.title(f"{folder_name} PDFs")
-    window.geometry("400x220")
+    width, height = 400, 220
+    window.geometry(f"{width}x{height}")
     window.resizable(False, False)
+    window.update_idletasks()
+    x = (window.winfo_screenwidth() - width) // 2
+    y = (window.winfo_screenheight() - height) // 2
+    window.geometry(f"{width}x{height}+{x}+{y}")
 
     ttk.Label(window, text=f"Select a PDF from {folder_name}", font=("Segoe UI", 11)).pack(pady=10)
 
@@ -68,8 +73,13 @@ def show_pdf_list(folder_name):
 # Main Window
 root = tk.Tk()
 root.title("Open a PDF File")
-root.geometry("360x250")
+width, height = 360, 250
+root.geometry(f"{width}x{height}")
 root.resizable(False, False)
+root.update_idletasks()
+x = (root.winfo_screenwidth() - width) // 2
+y = (root.winfo_screenheight() - height) // 2
+root.geometry(f"{width}x{height}+{x}+{y}")
 
 ttk.Label(root, text="Choose a PDF to view:", font=("Segoe UI", 13, "bold")).pack(pady=15)
 


### PR DESCRIPTION
## Summary
- Bundle fonts in Appointments generator to avoid hard-coded paths
- Center windows for Appointments, Payments, Pending, and PDF viewer modules

## Testing
- `python -m py_compile home.py fonts_loader.py Appointments/main_v2.py Payments/main_v2.py Pending/main_v2.py pdf.py`
- `pip install pyinstaller` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68bedeaf92c4832aa539a2af1f885f2a