### PR TITLE
Add installer build script and include bundled fonts

### DIFF
--- a/build_installer.py
+++ b/build_installer.py
@@ -1,0 +1,26 @@
+"""Build a standalone executable with PyInstaller including fonts and assets."""
+from __future__ import annotations
+
+import os
+import PyInstaller.__main__
+
+
+def build() -> None:
+    sep = ';' if os.name == 'nt' else ':'
+    datas = [
+        f"Header.jpg{sep}.",
+        f"Fonts{os.sep}Armata-Regular.ttf{sep}Fonts",
+        f"Fonts{os.sep}Novecentowide-Bold.ttf{sep}Fonts",
+        f"Fonts{os.sep}Novecentowide-DemiBold_0.ttf{sep}Fonts",
+    ]
+    PyInstaller.__main__.run([
+        "home.py",
+        "--name", "ScriptLauncher",
+        "--windowed",
+        "--onefile",
+        *[f"--add-data={d}" for d in datas],
+    ])
+
+
+if __name__ == "__main__":
+    build()

--- a/common_paths.py
+++ b/common_paths.py
@@ -12,7 +12,11 @@ APP_NAME = "ScriptLauncher"
 def base_dir() -> Path:
     """Return directory containing this application or executable."""
     if getattr(sys, "frozen", False):
-        return Path(sys.executable).parent
+        # When bundled with PyInstaller ``sys._MEIPASS`` points to the
+        # temporary extraction directory that holds bundled data files.  Use
+        # it when available so relative resources like fonts are found both in
+        # one-file and one-folder distributions.
+        return Path(getattr(sys, "_MEIPASS", Path(sys.executable).parent))
     return Path(__file__).resolve().parent
 
 

--- a/home.py
+++ b/home.py
@@ -4,12 +4,17 @@ import sys, os, shutil, subprocess
 from pathlib import Path
 
 from fonts_loader import load_private_fonts  # OK at top level (no Tk side-effects)
+from font_utils import install_fonts
 
 APP_NAME = "ScriptLauncher"
 
 def base_dir() -> Path:
     if getattr(sys, "frozen", False):
-        return Path(sys.executable).parent
+        # When running as a PyInstaller bundle, data files such as fonts are
+        # unpacked to ``sys._MEIPASS``.  Prefer that directory so bundled
+        # resources are located correctly in both one-file and one-folder
+        # distributions.
+        return Path(getattr(sys, "_MEIPASS", Path(sys.executable).parent))
     return Path(__file__).resolve().parent
 
 def data_dir() -> Path:
@@ -58,11 +63,14 @@ def main():
     # Ensure relative resources resolve beside the executable
     os.chdir(base_dir())
 
-    # Load private fonts before creating tkfont.Font objects
+    # Install bundled fonts (best-effort) and load them privately so Tkinter can
+    # use them even on systems where they are not pre-installed.
+    fonts_dir = base_dir() / "Fonts"
+    install_fonts(str(fonts_dir))
     load_private_fonts([
-        base_dir() / "Fonts" / "Armata-Regular.ttf",
-        base_dir() / "Fonts" / "Novecentowide-Bold.ttf",
-        base_dir() / "Fonts" / "Novecentowide-DemiBold_0.ttf",
+        fonts_dir / "Armata-Regular.ttf",
+        fonts_dir / "Novecentowide-Bold.ttf",
+        fonts_dir / "Novecentowide-DemiBold_0.ttf",
     ])
 
     def choose_family(preferred_names, fallbacks=("Segoe UI", "Arial", "Tahoma")):


### PR DESCRIPTION
## Summary
- Add `build_installer.py` script to generate a standalone executable with PyInstaller
- Load and install bundled fonts at runtime and detect PyInstaller's temporary directory
- Improve base path detection for frozen builds so data files resolve correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python build_installer.py` *(fails: ModuleNotFoundError: No module named 'PyInstaller')*
- `pip install pyinstaller` *(fails: Could not find a version that satisfies the requirement pyinstaller; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68beee23c040832aaa8dcec1e7afde28