### PR TITLE
Improve window sizing and button borders

### DIFF
--- a/Appointments/main_v2.py
+++ b/Appointments/main_v2.py
@@ -138,15 +138,27 @@ cal_label.pack()
 cal = Calendar(frame, selectmode="day", date_pattern="mm/dd/yy")
 cal.pack(pady=10)
 
-btn_generate = tk.Button(frame, text="Load & Generate PDF", command=generate_pdf, width=30, pady=10, bg="white")
+btn_generate = tk.Button(
+    frame,
+    text="Load & Generate PDF",
+    command=generate_pdf,
+    width=30,
+    pady=10,
+    bg="white",
+    bd=1,
+    relief="solid",
+)
 btn_generate.pack(pady=10)
+
+
 def center_window(win):
     win.update_idletasks()
-    width = win.winfo_width()
-    height = win.winfo_height()
+    width = win.winfo_reqwidth() + 20
+    height = win.winfo_reqheight() + 20
     x = (win.winfo_screenwidth() - width) // 2
     y = (win.winfo_screenheight() - height) // 2
     win.geometry(f"{width}x{height}+{x}+{y}")
+
 
 center_window(root)
 root.resizable(False, False)

--- a/Payments/main_v2.py
+++ b/Payments/main_v2.py
@@ -137,15 +137,27 @@ from tkcalendar import Calendar
 cal = Calendar(frame, selectmode="day", date_pattern="mm/dd/yy")
 cal.pack(pady=10)
 
-btn_generate = tk.Button(frame, text="Generate Payment PDF", command=generate_payment_pdf, width=30, pady=10, bg="white")
+btn_generate = tk.Button(
+    frame,
+    text="Generate Payment PDF",
+    command=generate_payment_pdf,
+    width=30,
+    pady=10,
+    bg="white",
+    bd=1,
+    relief="solid",
+)
 btn_generate.pack(pady=10)
+
+
 def center_window(win):
     win.update_idletasks()
-    width = win.winfo_width()
-    height = win.winfo_height()
+    width = win.winfo_reqwidth() + 20
+    height = win.winfo_reqheight() + 20
     x = (win.winfo_screenwidth() - width) // 2
     y = (win.winfo_screenheight() - height) // 2
     win.geometry(f"{width}x{height}+{x}+{y}")
+
 
 center_window(root)
 root.resizable(False, False)

--- a/Pending/main_v2.py
+++ b/Pending/main_v2.py
@@ -138,15 +138,27 @@ tk.Label(frame, text="Select a Date:", bg="white").pack()
 cal = Calendar(frame, selectmode="day", date_pattern="mm/dd/yy")
 cal.pack(pady=10)
 
-btn_generate = tk.Button(frame, text="Generate Pending PDF", command=generate_pending_pdf, width=30, pady=10, bg="white")
+btn_generate = tk.Button(
+    frame,
+    text="Generate Pending PDF",
+    command=generate_pending_pdf,
+    width=30,
+    pady=10,
+    bg="white",
+    bd=1,
+    relief="solid",
+)
 btn_generate.pack(pady=10)
+
+
 def center_window(win):
     win.update_idletasks()
-    width = win.winfo_width()
-    height = win.winfo_height()
+    width = win.winfo_reqwidth() + 20
+    height = win.winfo_reqheight() + 20
     x = (win.winfo_screenwidth() - width) // 2
     y = (win.winfo_screenheight() - height) // 2
     win.geometry(f"{width}x{height}+{x}+{y}")
+
 
 center_window(root)
 root.resizable(False, False)

--- a/pdf.py
+++ b/pdf.py
@@ -52,14 +52,10 @@ def show_pdf_list(folder_name):
                     messagebox.showerror("Error", f"Could not delete PDF:\n{e}")
 
     window = tk.Toplevel()
+    window.withdraw()
     window.title(f"{folder_name} PDFs")
     width, height = 400, 220
-    window.geometry(f"{width}x{height}")
     window.resizable(False, False)
-    window.update_idletasks()
-    x = (window.winfo_screenwidth() - width) // 2
-    y = (window.winfo_screenheight() - height) // 2
-    window.geometry(f"{width}x{height}+{x}+{y}")
 
     ttk.Label(window, text=f"Select a PDF from {folder_name}", font=("Segoe UI", 11)).pack(pady=10)
 
@@ -70,16 +66,18 @@ def show_pdf_list(folder_name):
     ttk.Button(window, text="📂 Open", command=open_selected_pdf).pack(pady=5, ipady=5)
     ttk.Button(window, text="🗑️ Delete", command=delete_selected_pdf).pack(pady=5, ipady=5)
 
+    window.update_idletasks()
+    x = (window.winfo_screenwidth() - width) // 2
+    y = (window.winfo_screenheight() - height) // 2
+    window.geometry(f"{width}x{height}+{x}+{y}")
+    window.deiconify()
+
 # Main Window
 root = tk.Tk()
+root.withdraw()
 root.title("Open a PDF File")
 width, height = 360, 250
-root.geometry(f"{width}x{height}")
 root.resizable(False, False)
-root.update_idletasks()
-x = (root.winfo_screenwidth() - width) // 2
-y = (root.winfo_screenheight() - height) // 2
-root.geometry(f"{width}x{height}+{x}+{y}")
 
 ttk.Label(root, text="Choose a PDF to view:", font=("Segoe UI", 13, "bold")).pack(pady=15)
 
@@ -87,4 +85,9 @@ ttk.Button(root, text="📄 Appointments", command=lambda: show_pdf_list("Appoin
 ttk.Button(root, text="💰 Payments", command=lambda: show_pdf_list("Payments"), width=30).pack(pady=5, ipady=5)
 ttk.Button(root, text="🕒 Pending", command=lambda: show_pdf_list("Pending"), width=30).pack(pady=5, ipady=5)
 
+root.update_idletasks()
+x = (root.winfo_screenwidth() - width) // 2
+y = (root.winfo_screenheight() - height) // 2
+root.geometry(f"{width}x{height}+{x}+{y}")
+root.deiconify()
 root.mainloop()


### PR DESCRIPTION
## Summary
- Add borders and extra padding to buttons in appointments, payments and pending tools
- Center and enlarge windows to fit content
- Center PDF viewer windows before showing to avoid flicker

## Testing
- `python -m py_compile Appointments/main_v2.py Payments/main_v2.py Pending/main_v2.py pdf.py`

------
https://chatgpt.com/codex/tasks/task_b_68bf93a078f0832aa00a1c6e4e1106b1