### PR TITLE
Load fonts from project directory for portability

### DIFF
--- a/Appointments/main.py
+++ b/Appointments/main.py
@@ -2,6 +2,11 @@ from fpdf import FPDF
 import csv
 from datetime import datetime
 from datetime import date
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from common_paths import base_dir
 
 
 now = date.today()
@@ -10,7 +15,7 @@ var_date = now.strftime("%Y-%m-%d")
 
 class PDF(FPDF):
     def header(self):
-        self.image('Header.jpg', 27.5, 0, 150, 35)
+        self.image(str(base_dir() / 'Header.jpg'), 27.5, 0, 150, 35)
         self.ln(20)
         self.set_font('Novecento Wide Demi Bold', 'B', 9)
         self.cell(0, 0, 'LIST OF APPOINTMENTS FOR ' + str(var_date), 'L')
@@ -29,13 +34,15 @@ class PDF(FPDF):
         pdf.ln(2)
 
 
+root_dir = base_dir()
+font_dir = root_dir / 'Fonts'
+
 pdf = PDF(orientation='P', unit='mm', format='A4')
-pdf.add_font('Novecento Wide Demi Bold', 'B',
-             r"C:\Users\user\AppData\Local\Microsoft\Windows\Fonts\Novecentowide-Bold.ttf", uni=True)
-pdf.add_font('Armata Regular', '', r"C:\Users\user\AppData\Local\Microsoft\Windows\Fonts\Armata-Regular.ttf", uni=True)
-pdf.add_font('Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf", uni=True)
-pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf", uni=True)
-pdf.add_font('Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf", uni=True)
+pdf.add_font('Novecento Wide Demi Bold', 'B', str(font_dir / 'Novecentowide-Bold.ttf'), uni=True)
+pdf.add_font('Armata Regular', '', str(font_dir / 'Armata-Regular.ttf'), uni=True)
+pdf.add_font('Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf", uni=True)
+pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf", uni=True)
+pdf.add_font('Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf", uni=True)
 pdf.add_page()
 pdf.alias_nb_pages()
 pdf.set_margins(10, 12, 12)

--- a/Payments/main.py
+++ b/Payments/main.py
@@ -2,6 +2,11 @@ from fpdf import FPDF
 import csv
 from datetime import datetime
 from datetime import date
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from common_paths import base_dir
 
 now = date.today()
 var_date = now.strftime("%Y-%m-%d")
@@ -9,7 +14,7 @@ var_date = now.strftime("%Y-%m-%d")
 
 class PDF(FPDF):
     def header(self):
-        self.image('Header.jpg', 27.5, 0, 150, 35)
+        self.image(str(base_dir() / 'Header.jpg'), 27.5, 0, 150, 35)
         self.ln(20)
         self.set_font('Novecento Wide Demi Bold', 'B', 9)
         self.cell(0, 0, 'LIST OF APPOINTMENTS FOR ' + str(var_date), 'L')
@@ -27,18 +32,16 @@ class PDF(FPDF):
         pdf.ln(2)
 
 
+root_dir = base_dir()
+font_dir = root_dir / 'Fonts'
+
 pdf = PDF(orientation='P', unit='mm', format='A4')
 
-'''
-    Change the file path of Novecento and Armata. :)    
-'''
-
-pdf.add_font('Novecento Wide Demi Bold', 'B',
-             r"C:\Users\Asian Land\AppData\Local\Microsoft\Windows\Fonts\Novecentowide-Bold.ttf", uni=True)
-pdf.add_font('Armata Regular', '', r"C:\Users\Asian Land\AppData\Local\Microsoft\Windows\Fonts\Armata-Regular.ttf", uni=True)
-pdf.add_font('Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf", uni=True)
-pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf", uni=True)
-pdf.add_font('Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf", uni=True)
+pdf.add_font('Novecento Wide Demi Bold', 'B', str(font_dir / 'Novecentowide-Bold.ttf'), uni=True)
+pdf.add_font('Armata Regular', '', str(font_dir / 'Armata-Regular.ttf'), uni=True)
+pdf.add_font('Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf", uni=True)
+pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf", uni=True)
+pdf.add_font('Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf", uni=True)
 pdf.add_page()
 pdf.alias_nb_pages()
 pdf.set_margins(10, 12, 12)

--- a/Pending/main.py
+++ b/Pending/main.py
@@ -2,6 +2,11 @@ from fpdf import FPDF
 import csv
 from datetime import datetime
 from datetime import date
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from common_paths import base_dir
 
 now = date.today()
 var_date = now.strftime("%Y-%m-%d")
@@ -10,7 +15,7 @@ var_date_num = now.strftime("%m")
 
 class PDF(FPDF):
     def header(self):
-        self.image('Header.jpg', 27.5, 0, 150, 35)
+        self.image(str(base_dir() / 'Header.jpg'), 27.5, 0, 150, 35)
         self.ln(20)
         self.set_font('Novecento Wide Demi Bold', 'B', 9)
         self.cell(0, 0, 'LIST OF PENDING APPOINTMENTS AS OF ' + str(var_date), 'L')
@@ -29,14 +34,16 @@ class PDF(FPDF):
         pdf.ln(2)
 
 
+root_dir = base_dir()
+font_dir = root_dir / 'Fonts'
+
 pdf = PDF(orientation='P', unit='mm', format='A4')
 
-pdf.add_font('Novecento Wide Demi Bold', 'B',
-             r"C:\Users\Asian Land\AppData\Local\Microsoft\Windows\Fonts\Novecentowide-Bold.ttf", uni=True)
-pdf.add_font('Armata Regular', '', r"C:\Users\Asian Land\AppData\Local\Microsoft\Windows\Fonts\Armata-Regular.ttf", uni=True)
-pdf.add_font('Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf", uni=True)
-pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf", uni=True)
-pdf.add_font('Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf", uni=True)
+pdf.add_font('Novecento Wide Demi Bold', 'B', str(font_dir / 'Novecentowide-Bold.ttf'), uni=True)
+pdf.add_font('Armata Regular', '', str(font_dir / 'Armata-Regular.ttf'), uni=True)
+pdf.add_font('Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf", uni=True)
+pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf", uni=True)
+pdf.add_font('Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf", uni=True)
 pdf.add_page()
 pdf.alias_nb_pages()
 pdf.set_margins(10, 12, 12)


### PR DESCRIPTION
## Summary
- Resolve header images and bundled fonts relative to the application directory
- Remove hard-coded font locations so PDF tools use fonts shipped with the project

## Testing
- `python -m py_compile Appointments/main.py Payments/main.py Pending/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68bf96b39b60832a9c076ef4db8c4339