### PR TITLE
Gracefully handle missing fonts

### DIFF
--- a/Appointments/main.py
+++ b/Appointments/main.py
@@ -7,25 +7,32 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from common_paths import base_dir
+from font_utils import safe_add_font
 
 
 now = date.today()
 var_date = now.strftime("%Y-%m-%d")
+
+novecento_font = "Helvetica"
+armata_font = "Helvetica"
+treb_bold_font = "Helvetica"
+treb_bolditalic_font = "Helvetica"
+treb_regular_font = "Helvetica"
 
 
 class PDF(FPDF):
     def header(self):
         self.image(str(base_dir() / 'Header.jpg'), 27.5, 0, 150, 35)
         self.ln(20)
-        self.set_font('Novecento Wide Demi Bold', 'B', 9)
+        self.set_font(novecento_font, 'B', 9)
         self.cell(0, 0, 'LIST OF APPOINTMENTS FOR ' + str(var_date), 'L')
         self.ln(4)
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(0, 0, 'ALSC Services', 'L')
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(4, 0, 'Page ' + str(self.page_no()) + ' of {nb}', 0, 0, 'R')
         pdf.ln(2)
-        self.set_font('Trebuchet MS Bold', 'B', 7)
+        self.set_font(treb_bold_font, 'B', 7)
         self.set_fill_color(180)
         self.cell(0, 5, 'No.        Res        Service                                        '
                         'Start             End              Status               '
@@ -38,11 +45,11 @@ root_dir = base_dir()
 font_dir = root_dir / 'Fonts'
 
 pdf = PDF(orientation='P', unit='mm', format='A4')
-pdf.add_font('Novecento Wide Demi Bold', 'B', str(font_dir / 'Novecentowide-Bold.ttf'), uni=True)
-pdf.add_font('Armata Regular', '', str(font_dir / 'Armata-Regular.ttf'), uni=True)
-pdf.add_font('Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf", uni=True)
-pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf", uni=True)
-pdf.add_font('Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf", uni=True)
+novecento_font = safe_add_font(pdf, 'Novecento Wide Demi Bold', 'B', font_dir / 'Novecentowide-Bold.ttf')
+armata_font = safe_add_font(pdf, 'Armata Regular', '', font_dir / 'Armata-Regular.ttf')
+treb_bold_font = safe_add_font(pdf, 'Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf")
+treb_bolditalic_font = safe_add_font(pdf, 'Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf")
+treb_regular_font = safe_add_font(pdf, 'Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf")
 pdf.add_page()
 pdf.alias_nb_pages()
 pdf.set_margins(10, 12, 12)
@@ -54,7 +61,7 @@ col_width3 = page_width / 10
 
 th = 5
 
-pdf.set_font('Trebuchet MS Regular', '', 7)
+pdf.set_font(treb_regular_font, '', 7)
 
 
 with open('appointments_2025-07-10.csv', 'r', newline='', encoding='utf8') as f:
@@ -81,7 +88,7 @@ with open('appointments_2025-07-10.csv', 'r', newline='', encoding='utf8') as f:
             pdf.ln(5)
 
 
-pdf.set_font('Trebuchet MS Bold Italic', 'BI', 7)
+pdf.set_font(treb_bolditalic_font, 'BI', 7)
 pdf.ln(5)
 pdf.cell(page_width, 0.0, '***Nothing Follows***', align='C')
 c_var_date = now.strftime("%Y%m%d")

--- a/Appointments/main_v2.py
+++ b/Appointments/main_v2.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from common_paths import base_dir, data_dir, find_latest_csv
+from font_utils import safe_add_font
 
 # Example A: open the latest "appointments_" CSV automatically
 csv_path = find_latest_csv(prefix="appointments_")
@@ -20,19 +21,26 @@ if not csv_path:
     )
     raise SystemExit(1)
 
+novecento_font = "Helvetica"
+armata_font = "Helvetica"
+treb_bold_font = "Helvetica"
+treb_bolditalic_font = "Helvetica"
+treb_regular_font = "Helvetica"
+
+
 class PDF(FPDF):
     def header(self):
         self.image(str(base_dir() / 'Header.jpg'), 27.5, 0, 150, 35)
         self.ln(20)
-        self.set_font('Novecento Wide Demi Bold', 'B', 9)
+        self.set_font(novecento_font, 'B', 9)
         self.cell(0, 0, 'LIST OF APPOINTMENTS FOR ' + str(var_date), 'L')
         self.ln(4)
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(0, 0, 'ALSC Services', 'L')
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(4, 0, 'Page ' + str(self.page_no()) + ' of {nb}', 0, 0, 'R')
         self.ln(2)
-        self.set_font('Trebuchet MS Bold', 'B', 7)
+        self.set_font(treb_bold_font, 'B', 7)
         self.set_fill_color(180)
         self.cell(0, 5, 'No.        Res        Service                                        '
                         'Start             End              Status               '
@@ -54,25 +62,16 @@ def generate_pdf():
             messagebox.showerror("File Not Found", f"CSV file not found for date: {var_date}")
             return
 
+        global novecento_font, armata_font, treb_bold_font, treb_bolditalic_font, treb_regular_font
         pdf = PDF(orientation='P', unit='mm', format='A4')
 
         root_dir = base_dir()
         font_dir = root_dir / "Fonts"
-        pdf.add_font(
-            'Novecento Wide Demi Bold',
-            'B',
-            str(font_dir / 'Novecentowide-Bold.ttf'),
-            uni=True,
-        )
-        pdf.add_font(
-            'Armata Regular',
-            '',
-            str(font_dir / 'Armata-Regular.ttf'),
-            uni=True,
-        )
-        pdf.add_font('Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf", uni=True)
-        pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf", uni=True)
-        pdf.add_font('Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf", uni=True)
+        novecento_font = safe_add_font(pdf, 'Novecento Wide Demi Bold', 'B', font_dir / 'Novecentowide-Bold.ttf')
+        armata_font = safe_add_font(pdf, 'Armata Regular', '', font_dir / 'Armata-Regular.ttf')
+        treb_bold_font = safe_add_font(pdf, 'Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf")
+        treb_bolditalic_font = safe_add_font(pdf, 'Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf")
+        treb_regular_font = safe_add_font(pdf, 'Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf")
 
         pdf.add_page()
         pdf.alias_nb_pages()
@@ -80,7 +79,7 @@ def generate_pdf():
         page_width = pdf.w - 2 * pdf.l_margin
         th = 5
 
-        pdf.set_font('Trebuchet MS Regular', '', 7)
+        pdf.set_font(treb_regular_font, '', 7)
 
         with open(csv_path, 'r', newline='', encoding='utf8') as f:
             reader = csv.reader(f)
@@ -106,7 +105,7 @@ def generate_pdf():
                     pdf.ln(1)
                     pdf.ln(5)
 
-        pdf.set_font('Trebuchet MS Bold Italic', 'BI', 7)
+        pdf.set_font(treb_bolditalic_font, 'BI', 7)
         pdf.ln(5)
         pdf.cell(page_width, 0.0, '***Nothing Follows***', align='C')
 

--- a/Payments/main.py
+++ b/Payments/main.py
@@ -7,24 +7,31 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from common_paths import base_dir
+from font_utils import safe_add_font
 
 now = date.today()
 var_date = now.strftime("%Y-%m-%d")
+
+novecento_font = "Helvetica"
+armata_font = "Helvetica"
+treb_bold_font = "Helvetica"
+treb_bolditalic_font = "Helvetica"
+treb_regular_font = "Helvetica"
 
 
 class PDF(FPDF):
     def header(self):
         self.image(str(base_dir() / 'Header.jpg'), 27.5, 0, 150, 35)
         self.ln(20)
-        self.set_font('Novecento Wide Demi Bold', 'B', 9)
+        self.set_font(novecento_font, 'B', 9)
         self.cell(0, 0, 'LIST OF APPOINTMENTS FOR ' + str(var_date), 'L')
         self.ln(4)
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(0, 0, 'Payments', 'L')
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(4, 0, 'Page ' + str(self.page_no()) + ' of {nb}', 0, 0, 'R')
         pdf.ln(2)
-        self.set_font('Trebuchet MS Bold', 'B', 7)
+        self.set_font(treb_bold_font, 'B', 7)
         self.set_fill_color(180)
         self.cell(0, 5, 'No.        Res         Service                  Date                    '
                         'Start                    End                     Status                 '
@@ -37,11 +44,11 @@ font_dir = root_dir / 'Fonts'
 
 pdf = PDF(orientation='P', unit='mm', format='A4')
 
-pdf.add_font('Novecento Wide Demi Bold', 'B', str(font_dir / 'Novecentowide-Bold.ttf'), uni=True)
-pdf.add_font('Armata Regular', '', str(font_dir / 'Armata-Regular.ttf'), uni=True)
-pdf.add_font('Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf", uni=True)
-pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf", uni=True)
-pdf.add_font('Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf", uni=True)
+novecento_font = safe_add_font(pdf, 'Novecento Wide Demi Bold', 'B', font_dir / 'Novecentowide-Bold.ttf')
+armata_font = safe_add_font(pdf, 'Armata Regular', '', font_dir / 'Armata-Regular.ttf')
+treb_bold_font = safe_add_font(pdf, 'Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf")
+treb_bolditalic_font = safe_add_font(pdf, 'Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf")
+treb_regular_font = safe_add_font(pdf, 'Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf")
 pdf.add_page()
 pdf.alias_nb_pages()
 pdf.set_margins(10, 12, 12)
@@ -53,7 +60,7 @@ col_width3 = page_width / 10
 
 th = 5
 
-pdf.set_font('Trebuchet MS Regular', '', 7)
+pdf.set_font(treb_regular_font, '', 7)
 
 
 try:
@@ -83,7 +90,7 @@ except:
     print("Please check your file name or the date format in your CSV file.")
 
 
-pdf.set_font('Trebuchet MS Bold Italic', 'BI', 7)
+pdf.set_font(treb_bolditalic_font, 'BI', 7)
 pdf.ln(5)
 pdf.cell(page_width, 0.0, '***Nothing Follows***', align='C')
 c_var_date = now.strftime("%Y%m%d")

--- a/Payments/main_v2.py
+++ b/Payments/main_v2.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from common_paths import base_dir, data_dir, find_latest_csv
+from font_utils import safe_add_font
 
 # Example A: open the latest "appointments_" CSV automatically
 csv_path = find_latest_csv(prefix="appointments_")
@@ -20,19 +21,26 @@ if not csv_path:
     )
     raise SystemExit(1)
 
+novecento_font = "Helvetica"
+armata_font = "Helvetica"
+treb_bold_font = "Helvetica"
+treb_bolditalic_font = "Helvetica"
+treb_regular_font = "Helvetica"
+
+
 class PDF(FPDF):
     def header(self):
         self.image(str(base_dir() / 'Header.jpg'), 27.5, 0, 150, 35)
         self.ln(20)
-        self.set_font('Novecento Wide Demi Bold', 'B', 9)
+        self.set_font(novecento_font, 'B', 9)
         self.cell(0, 0, 'LIST OF APPOINTMENTS FOR ' + str(var_date), 'L')
         self.ln(4)
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(0, 0, 'Payments', 'L')
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(4, 0, 'Page ' + str(self.page_no()) + ' of {nb}', 0, 0, 'R')
         self.ln(2)
-        self.set_font('Trebuchet MS Bold', 'B', 7)
+        self.set_font(treb_bold_font, 'B', 7)
         self.set_fill_color(180)
         self.cell(0, 5, 'No.        Res         Service                  Date                    '
                         'Start                    End                     Status                 '
@@ -52,25 +60,16 @@ def generate_payment_pdf():
             messagebox.showerror("File Not Found", f"CSV file not found for date: {var_date}")
             return
 
+        global novecento_font, armata_font, treb_bold_font, treb_bolditalic_font, treb_regular_font
         pdf = PDF(orientation='P', unit='mm', format='A4')
 
         root_dir = base_dir()
         font_dir = root_dir / "Fonts"
-        pdf.add_font(
-            'Novecento Wide Demi Bold',
-            'B',
-            str(font_dir / 'Novecentowide-Bold.ttf'),
-            uni=True,
-        )
-        pdf.add_font(
-            'Armata Regular',
-            '',
-            str(font_dir / 'Armata-Regular.ttf'),
-            uni=True,
-        )
-        pdf.add_font('Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf", uni=True)
-        pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf", uni=True)
-        pdf.add_font('Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf", uni=True)
+        novecento_font = safe_add_font(pdf, 'Novecento Wide Demi Bold', 'B', font_dir / 'Novecentowide-Bold.ttf')
+        armata_font = safe_add_font(pdf, 'Armata Regular', '', font_dir / 'Armata-Regular.ttf')
+        treb_bold_font = safe_add_font(pdf, 'Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf")
+        treb_bolditalic_font = safe_add_font(pdf, 'Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf")
+        treb_regular_font = safe_add_font(pdf, 'Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf")
 
         pdf.add_page()
         pdf.alias_nb_pages()
@@ -78,7 +77,7 @@ def generate_payment_pdf():
         page_width = pdf.w - 2 * pdf.l_margin
         th = 5
 
-        pdf.set_font('Trebuchet MS Regular', '', 7)
+        pdf.set_font(treb_regular_font, '', 7)
 
         with open(csv_path, newline='', encoding='utf8') as f:
             reader = csv.reader(f)
@@ -106,7 +105,7 @@ def generate_payment_pdf():
                     pdf.ln(1)
                     pdf.ln(5)
 
-        pdf.set_font('Trebuchet MS Bold Italic', 'BI', 7)
+        pdf.set_font(treb_bolditalic_font, 'BI', 7)
         pdf.ln(5)
         pdf.cell(page_width, 0.0, '***Nothing Follows***', align='C')
 

--- a/Pending/main.py
+++ b/Pending/main.py
@@ -7,25 +7,32 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from common_paths import base_dir
+from font_utils import safe_add_font
 
 now = date.today()
 var_date = now.strftime("%Y-%m-%d")
 var_date_num = now.strftime("%m")
+
+novecento_font = "Helvetica"
+armata_font = "Helvetica"
+treb_bold_font = "Helvetica"
+treb_bolditalic_font = "Helvetica"
+treb_regular_font = "Helvetica"
 
 
 class PDF(FPDF):
     def header(self):
         self.image(str(base_dir() / 'Header.jpg'), 27.5, 0, 150, 35)
         self.ln(20)
-        self.set_font('Novecento Wide Demi Bold', 'B', 9)
+        self.set_font(novecento_font, 'B', 9)
         self.cell(0, 0, 'LIST OF PENDING APPOINTMENTS AS OF ' + str(var_date), 'L')
         self.ln(4)
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(0, 0, 'ALSC Services', 'L')
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(5, 0, 'Page ' + str(self.page_no()) + ' of {nb}', 0, 0, 'R')
         pdf.ln(2)
-        self.set_font('Trebuchet MS Bold', 'B', 7)
+        self.set_font(treb_bold_font, 'B', 7)
         self.set_fill_color(180)
         self.cell(0, 5, 'No.   Res        Service                                 Date                '
                         'Start            End              Status            '
@@ -39,11 +46,11 @@ font_dir = root_dir / 'Fonts'
 
 pdf = PDF(orientation='P', unit='mm', format='A4')
 
-pdf.add_font('Novecento Wide Demi Bold', 'B', str(font_dir / 'Novecentowide-Bold.ttf'), uni=True)
-pdf.add_font('Armata Regular', '', str(font_dir / 'Armata-Regular.ttf'), uni=True)
-pdf.add_font('Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf", uni=True)
-pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf", uni=True)
-pdf.add_font('Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf", uni=True)
+novecento_font = safe_add_font(pdf, 'Novecento Wide Demi Bold', 'B', font_dir / 'Novecentowide-Bold.ttf')
+armata_font = safe_add_font(pdf, 'Armata Regular', '', font_dir / 'Armata-Regular.ttf')
+treb_bold_font = safe_add_font(pdf, 'Trebuchet MS Bold', 'B', r"C:\\Windows\\Fonts\\trebucbd.ttf")
+treb_bolditalic_font = safe_add_font(pdf, 'Trebuchet MS Bold Italic', 'BI', r"C:\\Windows\\Fonts\\trebucbi.ttf")
+treb_regular_font = safe_add_font(pdf, 'Trebuchet MS Regular', '', r"C:\\Windows\\Fonts\\trebuc.ttf")
 pdf.add_page()
 pdf.alias_nb_pages()
 pdf.set_margins(10, 12, 12)
@@ -55,7 +62,7 @@ col_width3 = page_width / 10
 
 th = 5
 
-pdf.set_font('Trebuchet MS Regular', '', 7)
+pdf.set_font(treb_regular_font, '', 7)
 
 
 with open('appointments_2025-07-10.csv', newline='', encoding='utf8') as f:
@@ -86,7 +93,7 @@ with open('appointments_2025-07-10.csv', newline='', encoding='utf8') as f:
             pdf.ln(5)
 
 
-pdf.set_font('Trebuchet MS Bold Italic', 'BI', 7)
+pdf.set_font(treb_bolditalic_font, 'BI', 7)
 pdf.ln(5)
 pdf.cell(page_width, 0.0, '***Nothing Follows***', align='C')
 c_var_date = now.strftime("%Y%m%d")

--- a/Pending/main_v2.py
+++ b/Pending/main_v2.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from common_paths import base_dir, data_dir, find_latest_csv
+from font_utils import safe_add_font
 
 # Example A: open the latest "appointments_" CSV automatically
 csv_path = find_latest_csv(prefix="appointments_")
@@ -20,19 +21,26 @@ if not csv_path:
     )
     raise SystemExit(1)
 
+novecento_font = "Helvetica"
+armata_font = "Helvetica"
+treb_bold_font = "Helvetica"
+treb_bolditalic_font = "Helvetica"
+treb_regular_font = "Helvetica"
+
+
 class PDF(FPDF):
     def header(self):
         self.image(str(base_dir() / 'Header.jpg'), 27.5, 0, 150, 35)
         self.ln(20)
-        self.set_font('Novecento Wide Demi Bold', 'B', 9)
+        self.set_font(novecento_font, 'B', 9)
         self.cell(0, 0, 'LIST OF PENDING APPOINTMENTS AS OF ' + str(var_date), 'L')
         self.ln(4)
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(0, 0, 'ALSC Services', 'L')
-        self.set_font('Armata Regular', '', 7)
+        self.set_font(armata_font, '', 7)
         self.cell(5, 0, 'Page ' + str(self.page_no()) + ' of {nb}', 0, 0, 'R')
         self.ln(2)
-        self.set_font('Trebuchet MS Bold', 'B', 7)
+        self.set_font(treb_bold_font, 'B', 7)
         self.set_fill_color(180)
         self.cell(0, 5, 'No.   Res        Service                                 Date                '
                         'Start            End              Status            '
@@ -54,30 +62,21 @@ def generate_pending_pdf():
             messagebox.showerror("File Not Found", f"CSV file not found: {csv_filename}")
             return
 
+        global novecento_font, armata_font, treb_bold_font, treb_bolditalic_font, treb_regular_font
         pdf = PDF(orientation='P', unit='mm', format='A4')
         root_dir = base_dir()
         font_dir = root_dir / "Fonts"
-        pdf.add_font(
-            'Novecento Wide Demi Bold',
-            'B',
-            str(font_dir / 'Novecentowide-Bold.ttf'),
-            uni=True,
-        )
-        pdf.add_font(
-            'Armata Regular',
-            '',
-            str(font_dir / 'Armata-Regular.ttf'),
-            uni=True,
-        )
-        pdf.add_font('Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf", uni=True)
-        pdf.add_font('Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf", uni=True)
-        pdf.add_font('Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf", uni=True)
+        novecento_font = safe_add_font(pdf, 'Novecento Wide Demi Bold', 'B', font_dir / 'Novecentowide-Bold.ttf')
+        armata_font = safe_add_font(pdf, 'Armata Regular', '', font_dir / 'Armata-Regular.ttf')
+        treb_bold_font = safe_add_font(pdf, 'Trebuchet MS Bold', 'B', r"C:\Windows\Fonts\trebucbd.ttf")
+        treb_bolditalic_font = safe_add_font(pdf, 'Trebuchet MS Bold Italic', 'BI', r"C:\Windows\Fonts\trebucbi.ttf")
+        treb_regular_font = safe_add_font(pdf, 'Trebuchet MS Regular', '', r"C:\Windows\Fonts\trebuc.ttf")
         pdf.add_page()
         pdf.alias_nb_pages()
         pdf.set_margins(10, 12, 12)
         page_width = pdf.w - 2 * pdf.l_margin
         th = 5
-        pdf.set_font('Trebuchet MS Regular', '', 7)
+        pdf.set_font(treb_regular_font, '', 7)
 
         with open(csv_path, newline='', encoding='utf8') as f:
             reader = csv.reader(f)
@@ -108,7 +107,7 @@ def generate_pending_pdf():
                     pdf.ln(1)
                     pdf.ln(5)
 
-        pdf.set_font('Trebuchet MS Bold Italic', 'BI', 7)
+        pdf.set_font(treb_bolditalic_font, 'BI', 7)
         pdf.ln(5)
         pdf.cell(page_width, 0.0, '***Nothing Follows***', align='C')
 

--- a/font_utils.py
+++ b/font_utils.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import sys
+from pathlib import Path
 
 
 def _system_fonts_dir() -> str:
@@ -32,3 +33,21 @@ def install_fonts(font_dir: str) -> None:
     except Exception:
         # Completely ignore any failure in font installation
         pass
+
+
+def safe_add_font(pdf, family: str, style: str, font_path: str | os.PathLike, *, uni: bool = True) -> str:
+    """Register *font_path* with ``pdf`` if it exists, returning a usable family name.
+
+    If the font file is missing or cannot be loaded, the built-in ``Helvetica``
+    family is returned so callers can safely fall back without raising
+    ``RuntimeError`` from :meth:`fpdf.FPDF.add_font` or :meth:`fpdf.FPDF.set_font`.
+    """
+
+    path = Path(font_path)
+    if path.exists():
+        try:
+            pdf.add_font(family, style, str(path), uni=uni)
+            return family
+        except Exception:
+            pass
+    return "Helvetica"


### PR DESCRIPTION
## Summary
- ensure missing font files fall back to Helvetica rather than crashing
- use new safe_add_font helper across Appointments, Payments, and Pending PDF generators

## Testing
- `python -m py_compile font_utils.py Appointments/main.py Appointments/main_v2.py Payments/main.py Payments/main_v2.py Pending/main.py Pending/main_v2.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bf9b400c5c832aaea237b2b110563e